### PR TITLE
Require any manufaturer data to be present in the advertised packets.

### DIFF
--- a/kbeaconlib2/src/main/java/com/kkmcn/kbeaconlib2/KBeaconsMgr.java
+++ b/kbeaconlib2/src/main/java/com/kkmcn/kbeaconlib2/KBeaconsMgr.java
@@ -327,7 +327,7 @@ public class KBeaconsMgr {
                     iBeaconFilter);
 
             ScanFilter.Builder filter4 = new ScanFilter.Builder().setManufacturerData(KBUtility.KKM_MANUFACTURE_ID,
-                    null);
+                    new byte[0]);
             filterList.add(filter1.build());
             filterList.add(filter2.build());
             filterList.add(filter3.build());


### PR DESCRIPTION
Use a byte instead of null value to enable the OS consider a scan useful and retain it when screen goes off. This applies to specific Samsung devices such as S9.

When this change is not present, the Samsung phone shows the following in the log before terminating the scan whenever the screen is turned off:

`[GSIM LOG]: gsimLogHandler, msg: MESSAGE_SCAN_STOP, appName: com.packagename.other, scannerId: 11, reportDelayMillis=0`